### PR TITLE
TypeError occurs when nothing is passed into Buffer class

### DIFF
--- a/lib/inputs/ProxyProtocol.js
+++ b/lib/inputs/ProxyProtocol.js
@@ -34,7 +34,7 @@ module.exports = function (server) {
             if (event == 'readable') {
                 var chunk = socket.read()
                 if (chunk === null) {
-                    chunk = new Buffer()
+                    chunk = new Buffer(0)
                 }
 
                 var line = chunk.toString('utf8'),


### PR DESCRIPTION
For node > 6.0 do `Buffer.alloc(0)` instead since Buffer() is deprecated. 

https://nodejs.org/api/buffer.html#buffer_class_method_buffer_alloc_size_fill_encoding