### PR TITLE
Adding Parser for Meraki logs. The initial version only parses WAP logs.

### DIFF
--- a/lib/parsers/index.js
+++ b/lib/parsers/index.js
@@ -66,6 +66,7 @@ module.exports = {
     relpSyslogParser: wrap(require('./relpSyslogParser')),
     sshdParser: wrap(require('./sshdParser')),
     sudoParser: wrap(require('./sudoParser')),
+    merakiParser: wrap(require('./merakiParser')),
 }
 
 /**

--- a/lib/parsers/merakiParser.js
+++ b/lib/parsers/merakiParser.js
@@ -1,0 +1,43 @@
+
+var regexes = [
+	{
+	name: 'meraki_wap',
+	regex: / \S+\d+ flows (disallow|allow) src=(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}) dst=(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}) mac=(([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})) protocol=\d+/,
+	parts: ['action', 'src_ip', 'dst_ip', 'mac']
+	}
+	]
+
+/**
+ * Parses log lines from Meraki
+ *
+ * @param {String} message Message to try and parse
+ *
+ * @returns {parserResult}
+ */
+module.exports = function (message) {
+
+var parts = [],
+	matched,
+	data = {}
+
+regexes.some(function (group) {
+  parts = group.regex.exec(message)
+	if (parts) {
+		matched = group
+		return true
+	}
+})
+
+if (!matched) {
+	return { data: void 0, error: 'No matches' }
+}
+
+data.event = matched.name
+matched.parts.forEach(function (name, index) {
+	data[name] = parts[index + 1].trim()
+})
+
+return { data: data, error: void 0 }
+}
+
+module.exports.propertyName = 'merakiParser'

--- a/test/parsers/merakiParser.test.js
+++ b/test/parsers/merakiParser.test.js
@@ -1,0 +1,32 @@
+var StreamStash = require('../../'),
+	assertParserResult = require('./util').assertParserResult
+
+describe('merakiParser', function () {
+	it('Should parse action=allow Meraki WAP Logs', function() {
+		assertParserResult(
+			StreamStash.parsers.merakiParser.raw,
+			'[0.0 WAP12 flows allow src=0.0.0.0 dst=198.179.1.255 mac=C4:B3:01:CF:70:C7 protocol=128]',
+			{
+				event: 'meraki_wap',
+				action: 'allow',
+				src_ip: '0.0.0.0',
+				dst_ip: '198.179.1.255',
+				mac: 'C4:B3:01:CF:70:C7',
+			}
+		)
+	})
+
+	it('Should parse action=disallow Meraki WAP logs', function() {
+		assertParserResult(
+			StreamStash.parsers.merakiParser.raw,
+			'[0.0 WAP12 flows disallow src=198.179.1.255 dst=198.168.1.172 mac=C4:B3:01:CF:70:C7 protocol=128]',
+			{
+				event: 'meraki_wap',
+				action: 'disallow',
+				src_ip: '198.179.1.255',
+				dst_ip: '198.168.1.172',
+				mac: 'C4:B3:01:CF:70:C7',
+			}
+		)
+	})
+})


### PR DESCRIPTION
 Changes to be committed:
	modified:   lib/parsers/index.js
	new file:   lib/parsers/merakiParser.js
	new file:   test/parsers/merakiParser.test.js