### PR TITLE
add dnstap info to goAuditParser

### DIFF
--- a/lib/parsers/goAuditParser.js
+++ b/lib/parsers/goAuditParser.js
@@ -225,8 +225,10 @@ var parseSockaddr = function (msgs, result, dnstap) {
     var msg = msgs.join(' '),
         data = splitFields(msg)
 
-    result.data.socket_address = parseAddr(data.saddr)
-    result.data.dnstap = dnstap
+    addr = parseAddr(data.saddr)
+
+    result.data.socket_address = addr
+    result.data.socket_hostname = dnstap[addr]
 }
 
 var parseProctitle = function (msgs, result) {

--- a/lib/parsers/goAuditParser.js
+++ b/lib/parsers/goAuditParser.js
@@ -27,7 +27,8 @@ module.exports = function (message) {
     }
 
     var uidMap = data['uid_map'] || {}
-
+    var dnstap = data['dnstap'] || {}
+    
     result.data = {
         timestamp: new Date(data.timestamp * 1000),
         sequence: data.sequence,
@@ -56,7 +57,7 @@ module.exports = function (message) {
                 parseCwd(msgs, result)
                 break
             case constants.types.sockaddr:
-                parseSockaddr(msgs, result)
+                parseSockaddr(msgs, result, dnstap)
                 break
             case constants.types.proctitle:
                 parseProctitle(msgs, result)
@@ -220,11 +221,12 @@ var parseCwd = function (msgs, result) {
     result.data.cwd = convertValue(data.cwd || '', true)
 }
 
-var parseSockaddr = function (msgs, result) {
+var parseSockaddr = function (msgs, result, dnstap) {
     var msg = msgs.join(' '),
         data = splitFields(msg)
 
     result.data.socket_address = parseAddr(data.saddr)
+    result.data.dnstap = dnstap
 }
 
 var parseProctitle = function (msgs, result) {


### PR DESCRIPTION
Get streamstash to add dnstap info from go-audit. 

Sample data from go-audit:
```{
  "sequence": 3989038,
  "timestamp": "1540829605.865",
  "messages": [
    {
      "type": 1300,
      "data": "arch=c000003e syscall=42 success=yes exit=0 a0=3 a1=7f4f68002a20 a2=10 a3=3babea5b84794f4 items=0 ppid=28810 pid=16868 auid=1000 uid=1000 gid=1000 euid=1000 suid=1000 fsuid=1000 egid=1000 sgid=1000 fsgid=1000 tty=pts7 ses=3 comm=\"curl\" exe=\"/usr/bin/curl\" key=(null)"
    },
    {
      "type": 1306,
      "data": "saddr=02000050C01EFD710000000000000000"
    },
    {
      "type": 1327,
      "data": "proctitle=6375726C006769746875622E636F6D"
    }
  ],
  "uid_map": {
    "1000": "alanlam"
  },
  "dnstap": {
    "192.30.253.113": "github.com"
  }
}